### PR TITLE
Save non-redacted Project Integration values into Terraform State

### DIFF
--- a/pkg/pipeline/configuration.go
+++ b/pkg/pipeline/configuration.go
@@ -1,0 +1,14 @@
+package pipeline
+
+type Configuration interface {
+	Id() string
+}
+
+func FindConfigurationById[C Configuration](configurations []C, id string) *C {
+	for _, configuration := range configurations {
+		if configuration.Id() == id {
+			return &configuration
+		}
+	}
+	return nil
+}

--- a/pkg/pipeline/resource_pipeline_project_integration.go
+++ b/pkg/pipeline/resource_pipeline_project_integration.go
@@ -100,6 +100,7 @@ func pipelineProjectIntegrationResource() *schema.Resource {
 					"is_sensitive": {
 						Type:        schema.TypeBool,
 						Optional:    true,
+						Default:     false,
 						Description: "Is the underlying Value sensitive or not",
 					},
 				},

--- a/pkg/pipeline/resource_pipeline_project_integration.go
+++ b/pkg/pipeline/resource_pipeline_project_integration.go
@@ -30,8 +30,13 @@ type ProjectIntegration struct {
 }
 
 type FormJSONValues struct {
-	Label string `json:"label"`
-	Value string `json:"value"`
+	Label     string `json:"label"`
+	Value     string `json:"value"`
+	Sensitive bool
+}
+
+func (f FormJSONValues) Id() string {
+	return f.Label
 }
 
 type ProjectJSON struct {
@@ -40,7 +45,6 @@ type ProjectJSON struct {
 }
 
 const projectIntegrationsUrl = "pipelines/api/v1/projectintegrations"
-const redactedSecretValue = "********"
 
 func pipelineProjectIntegrationResource() *schema.Resource {
 
@@ -92,6 +96,11 @@ func pipelineProjectIntegrationResource() *schema.Resource {
 						Type:        schema.TypeString,
 						Required:    true,
 						Description: "Value of the input property.",
+					},
+					"is_sensitive": {
+						Type:        schema.TypeBool,
+						Optional:    true,
+						Description: "Is the underlying Value sensitive or not",
 					},
 				},
 			},
@@ -160,6 +169,7 @@ func pipelineProjectIntegrationResource() *schema.Resource {
 		errors = append(errors, setValue("environments", projectIntegration.Environments)...)
 		errors = append(errors, setValue("is_internal", projectIntegration.IsInternal)...)
 		errors = append(errors, packProject(ctx, d, "project", projectIntegration.Project)...)
+		errors = append(errors, packFormJSONValues(ctx, d, "form_json_values", projectIntegration.FormJSONValues)...)
 
 		if len(errors) > 0 {
 			return diag.Errorf("failed to pack project integration %q", errors)
@@ -261,10 +271,40 @@ func unpackFormJSONValues(d *util.ResourceData, key string) []FormJSONValues {
 	for _, keyValue := range keyValues {
 		idx := keyValue.(map[string]interface{})
 		formJSONValue := FormJSONValues{
-			Label: idx["label"].(string),
-			Value: idx["value"].(string),
+			Label:     idx["label"].(string),
+			Value:     idx["value"].(string),
+			Sensitive: idx["is_sensitive"].(bool),
 		}
 		formJSONValues = append(formJSONValues, formJSONValue)
 	}
 	return formJSONValues
+}
+func packFormJSONValues(ctx context.Context, d *schema.ResourceData, schemaKey string, formJSONValues []FormJSONValues) []error {
+	setValue := util.MkLens(d)
+	var keyValues []interface{}
+	existingValues := unpackFormJSONValues(&util.ResourceData{ResourceData: d}, "form_json_values")
+
+	for _, idx := range formJSONValues {
+		keyValue := map[string]interface{}{
+			"label":        idx.Label,
+			"value":        idx.Value,
+			"is_sensitive": idx.Sensitive,
+		}
+
+		lookup := FindConfigurationById(existingValues, idx.Label)
+		// the API will always return the redacted value. Putting this into tf-state will cause a diff every time
+		// as it tries to correct "***" -> "secret_val".
+		if lookup != nil && lookup.Sensitive {
+			if lookup.Value != "" {
+				keyValue["value"] = lookup.Value
+			}
+			//the incoming `idx` value will always be false, the JFrog API has no concept of this field
+			keyValue["is_sensitive"] = true
+		}
+
+		tflog.Debug(ctx, "packFormJSONValues", keyValue)
+		keyValues = append(keyValues, keyValue)
+	}
+	errors := setValue(schemaKey, keyValues)
+	return errors
 }

--- a/pkg/pipeline/resource_pipeline_project_integration.go
+++ b/pkg/pipeline/resource_pipeline_project_integration.go
@@ -160,7 +160,6 @@ func pipelineProjectIntegrationResource() *schema.Resource {
 		errors = append(errors, setValue("environments", projectIntegration.Environments)...)
 		errors = append(errors, setValue("is_internal", projectIntegration.IsInternal)...)
 		errors = append(errors, packProject(ctx, d, "project", projectIntegration.Project)...)
-		errors = append(errors, packFormJSONValues(ctx, d, "form_json_values", projectIntegration.FormJSONValues)...)
 
 		if len(errors) > 0 {
 			return diag.Errorf("failed to pack project integration %q", errors)
@@ -268,44 +267,4 @@ func unpackFormJSONValues(d *util.ResourceData, key string) []FormJSONValues {
 		formJSONValues = append(formJSONValues, formJSONValue)
 	}
 	return formJSONValues
-}
-
-func lookupFormJSONValue(values []FormJSONValues, key string) FormJSONValues {
-	for _, value := range values {
-		if value.Label == key {
-			return value
-		}
-	}
-	return FormJSONValues{}
-}
-
-func packFormJSONValues(ctx context.Context, d *schema.ResourceData, schemaKey string, formJSONValues []FormJSONValues) []error {
-	setValue := util.MkLens(d)
-	var keyValues []interface{}
-	existingValues := unpackFormJSONValues(&util.ResourceData{ResourceData: d}, "form_json_values")
-	for _, idx := range formJSONValues {
-		keyValue := map[string]interface{}{
-			"label": idx.Label,
-			"value": idx.Value,
-		}
-		// the API will always return the redacted value. Putting this into tf-state will cause a diff every time
-		// as it tries to correct "***" -> "secret_val".
-		if idx.Value == "********" {
-			lookup := lookupFormJSONValue(existingValues, idx.Label)
-
-			if lookup.Value != "" {
-				tflog.Debug(ctx, "over-writing key value with existing data value", map[string]interface{}{
-					"label":    idx.Label,
-					"value":    idx.Value,
-					"override": lookup.Value,
-				})
-				keyValue["value"] = lookup.Value
-			}
-		}
-
-		tflog.Debug(ctx, "packFormJSONValues", keyValue)
-		keyValues = append(keyValues, keyValue)
-	}
-	errors := setValue(schemaKey, keyValues)
-	return errors
 }

--- a/pkg/pipeline/resource_pipeline_project_integration_test.go
+++ b/pkg/pipeline/resource_pipeline_project_integration_test.go
@@ -1,34 +1,81 @@
 package pipeline
 
 import (
+	"context"
 	"testing"
 
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
 const testFormJsonSchemaKey = "form_json_values"
+const redactedSecretValue = "********"
 
 func TestPackFormJSONValues(t *testing.T) {
 	testCases := map[string]struct {
-		input         map[string]string
-		existingState map[string]string
+		input         []FormJSONValues
+		existingState []FormJSONValues
 		result        map[string]string
 	}{
 		"no_asterisks": {
-			input:         map[string]string{"key_a": "not_a_secret", "key_b": "something_else"},
-			existingState: map[string]string{"key_a": "not_a_secret", "key_b": "something_else"},
-			result:        map[string]string{"key_a": "not_a_secret", "key_b": "something_else"},
+			input: []FormJSONValues{{
+				Label:     "key_a",
+				Value:     "not_a_secret",
+				Sensitive: false,
+			}, {
+				Label:     "key_b",
+				Value:     "something_else",
+				Sensitive: false,
+			},
+			},
+			existingState: []FormJSONValues{{
+				Label:     "key_a",
+				Value:     "not_a_secret",
+				Sensitive: false,
+			}, {
+				Label:     "key_b",
+				Value:     "something_else",
+				Sensitive: false,
+			},
+			},
+			result: map[string]string{"key_a": "not_a_secret", "key_b": "something_else"},
 		},
 		"with_asterisks": {
-			input:         map[string]string{"key_a": redactedSecretValue, "key_b": "something_else"},
-			existingState: map[string]string{"key_a": "super_secret", "key_b": "something_else"},
-			result:        map[string]string{"key_a": "super_secret", "key_b": "something_else"},
+			input: []FormJSONValues{{
+				Label:     "key_a",
+				Value:     redactedSecretValue,
+				Sensitive: true,
+			}, {
+				Label:     "key_b",
+				Value:     "something_else",
+				Sensitive: false,
+			},
+			},
+			existingState: []FormJSONValues{{
+				Label:     "key_a",
+				Value:     "super_secret",
+				Sensitive: true,
+			}, {
+				Label:     "key_b",
+				Value:     "something_else",
+				Sensitive: false,
+			},
+			},
+			result: map[string]string{"key_a": "super_secret", "key_b": "something_else"},
 		},
 		// this technically won't happen, even on resource create; the Input from terraform should have the real value
 		// this is just testing code path safety
 		"with_asterisks_no_state": {
-			input:         map[string]string{"key_a": redactedSecretValue, "key_b": "something_else"},
-			existingState: map[string]string{},
+			input: []FormJSONValues{{
+				Label:     "key_a",
+				Value:     redactedSecretValue,
+				Sensitive: false,
+			}, {
+				Label:     "key_b",
+				Value:     "something_else",
+				Sensitive: false,
+			},
+			},
+			existingState: []FormJSONValues{},
 			result:        map[string]string{"key_a": redactedSecretValue, "key_b": "something_else"},
 		},
 	}
@@ -38,10 +85,11 @@ func TestPackFormJSONValues(t *testing.T) {
 			projectSchemaResource := pipelineProjectIntegrationResource()
 			schemaData := projectSchemaResource.TestResourceData()
 			fJsonState := make([]interface{}, 0)
-			for k, v := range tcase.existingState {
+			for _, idx := range tcase.existingState {
 				fJsonState = append(fJsonState, map[string]interface{}{
-					"label": k,
-					"value": v,
+					"label":        idx.Label,
+					"value":        idx.Value,
+					"is_sensitive": idx.Sensitive,
 				})
 			}
 			err := schemaData.Set(testFormJsonSchemaKey, fJsonState)
@@ -49,15 +97,10 @@ func TestPackFormJSONValues(t *testing.T) {
 				t.Fatalf("error creating test schema %v", err)
 			}
 
-			fJsonInput := make([]FormJSONValues, 0)
-			for k, v := range tcase.input {
-				fJsonInput = append(fJsonInput, FormJSONValues{Label: k, Value: v})
+			errs := packFormJSONValues(context.TODO(), schemaData, testFormJsonSchemaKey, tcase.input)
+			for _, err2 := range errs {
+				t.Errorf("error bubbled from packFormJSONValues: %v", err2)
 			}
-
-			// errs := packFormJSONValues(context.TODO(), schemaData, testFormJsonSchemaKey, fJsonInput)
-			// for _, err2 := range errs {
-			// 	t.Errorf("error bubbled from packFormJSONValues: %v", err2)
-			// }
 
 			resultValues := unpackFormJSONValues(&util.ResourceData{ResourceData: schemaData}, testFormJsonSchemaKey)
 			for _, value := range resultValues {

--- a/pkg/pipeline/resource_pipeline_project_integration_test.go
+++ b/pkg/pipeline/resource_pipeline_project_integration_test.go
@@ -1,7 +1,6 @@
 package pipeline
 
 import (
-	"context"
 	"testing"
 
 	"github.com/jfrog/terraform-provider-shared/util"
@@ -55,10 +54,10 @@ func TestPackFormJSONValues(t *testing.T) {
 				fJsonInput = append(fJsonInput, FormJSONValues{Label: k, Value: v})
 			}
 
-			errs := packFormJSONValues(context.TODO(), schemaData, testFormJsonSchemaKey, fJsonInput)
-			for _, err2 := range errs {
-				t.Errorf("error bubbled from packFormJSONValues: %v", err2)
-			}
+			// errs := packFormJSONValues(context.TODO(), schemaData, testFormJsonSchemaKey, fJsonInput)
+			// for _, err2 := range errs {
+			// 	t.Errorf("error bubbled from packFormJSONValues: %v", err2)
+			// }
 
 			resultValues := unpackFormJSONValues(&util.ResourceData{ResourceData: schemaData}, testFormJsonSchemaKey)
 			for _, value := range resultValues {

--- a/pkg/pipeline/resource_pipeline_project_integration_test.go
+++ b/pkg/pipeline/resource_pipeline_project_integration_test.go
@@ -1,0 +1,72 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+const testFormJsonSchemaKey = "form_json_values"
+
+func TestPackFormJSONValues(t *testing.T) {
+	testCases := map[string]struct {
+		input         map[string]string
+		existingState map[string]string
+		result        map[string]string
+	}{
+		"no_asterisks": {
+			input:         map[string]string{"key_a": "not_a_secret", "key_b": "something_else"},
+			existingState: map[string]string{"key_a": "not_a_secret", "key_b": "something_else"},
+			result:        map[string]string{"key_a": "not_a_secret", "key_b": "something_else"},
+		},
+		"with_asterisks": {
+			input:         map[string]string{"key_a": redactedSecretValue, "key_b": "something_else"},
+			existingState: map[string]string{"key_a": "super_secret", "key_b": "something_else"},
+			result:        map[string]string{"key_a": "super_secret", "key_b": "something_else"},
+		},
+		// this technically won't happen, even on resource create; the Input from terraform should have the real value
+		// this is just testing code path safety
+		"with_asterisks_no_state": {
+			input:         map[string]string{"key_a": redactedSecretValue, "key_b": "something_else"},
+			existingState: map[string]string{},
+			result:        map[string]string{"key_a": redactedSecretValue, "key_b": "something_else"},
+		},
+	}
+
+	for name, tcase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			projectSchemaResource := pipelineProjectIntegrationResource()
+			schemaData := projectSchemaResource.TestResourceData()
+			fJsonState := make([]interface{}, 0)
+			for k, v := range tcase.existingState {
+				fJsonState = append(fJsonState, map[string]interface{}{
+					"label": k,
+					"value": v,
+				})
+			}
+			err := schemaData.Set(testFormJsonSchemaKey, fJsonState)
+			if err != nil {
+				t.Fatalf("error creating test schema %v", err)
+			}
+
+			fJsonInput := make([]FormJSONValues, 0)
+			for k, v := range tcase.input {
+				fJsonInput = append(fJsonInput, FormJSONValues{Label: k, Value: v})
+			}
+
+			errs := packFormJSONValues(context.TODO(), schemaData, testFormJsonSchemaKey, fJsonInput)
+			for _, err2 := range errs {
+				t.Errorf("error bubbled from packFormJSONValues: %v", err2)
+			}
+
+			resultValues := unpackFormJSONValues(&util.ResourceData{ResourceData: schemaData}, testFormJsonSchemaKey)
+			for _, value := range resultValues {
+				k := value.Label
+				if tcase.result[k] != value.Value {
+					t.Errorf("key %s returned %s; expected %s", k, value.Value, tcase.result[k])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change will store the actual project integration "secret' values into the Terraform state. 

Right now, the Resource is created with the secret values, and then there is a call to `readProjectIntegration` immediately after. This will return `form_json_values` that have a redacted string `"********"` instead of the secret values. 

That redacted value is then stored in the Terraform state. On a subsequent plan, Terraform will see the secret value as an input, and it will see that the state/ results from `readProjectIntegration` is the redacted value. This will result in integrations being marked as "dirty" for every plan/apply. 

First commit contains the fix, second has refactoring to support unit tests. 